### PR TITLE
updating the testing of opfcli-onboard after paper kustomization updates

### DIFF
--- a/cluster-scope/base/core/namespaces/testproject/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/testproject/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - namespace.yaml
+components:
+    - ../../../../components/project-admin-rolebindings/testgroup
+    - ../../../../components/resourcequotas/small
+    - ../../../../components/limitranges/default
+namespace: testproject

--- a/cluster-scope/base/core/namespaces/testproject/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/testproject/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+    name: testproject
+    annotations:
+        openshift.io/requester: testgroup

--- a/cluster-scope/base/user.openshift.io/groups/testgroup/group.yaml
+++ b/cluster-scope/base/user.openshift.io/groups/testgroup/group.yaml
@@ -1,0 +1,5 @@
+apiVersion: user.openshift.io/v1
+kind: Group
+metadata:
+    name: testgroup
+users: []

--- a/cluster-scope/base/user.openshift.io/groups/testgroup/kustomization.yaml
+++ b/cluster-scope/base/user.openshift.io/groups/testgroup/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - group.yaml

--- a/cluster-scope/components/project-admin-rolebindings/testgroup/kustomization.yaml
+++ b/cluster-scope/components/project-admin-rolebindings/testgroup/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+    - rbac.yaml

--- a/cluster-scope/components/project-admin-rolebindings/testgroup/rbac.yaml
+++ b/cluster-scope/components/project-admin-rolebindings/testgroup/rbac.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: namespace-admin-testgroup
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: admin
+subjects:
+    - apiGroup: rbac.authorization.k8s.io
+      kind: Group
+      name: testgroup

--- a/cluster-scope/overlays/prod/common/kustomization.yaml
+++ b/cluster-scope/overlays/prod/common/kustomization.yaml
@@ -52,6 +52,7 @@ resources:
 - ../../../base/user.openshift.io/groups/sre
 - ../../../base/user.openshift.io/groups/superset-user
 - ../../../base/user.openshift.io/groups/team-pixel
+- ../../../base/user.openshift.io/groups/testgroup
 - ../../../base/user.openshift.io/groups/thoth
 - ../../../base/user.openshift.io/groups/thoth-devops
 - ../../../base/user.openshift.io/groups/tremor-demo

--- a/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
+++ b/cluster-scope/overlays/prod/moc/smaug/kustomization.yaml
@@ -24,8 +24,8 @@ resources:
 - ../../../../base/core/namespaces/aicoe-meteor
 - ../../../../base/core/namespaces/apicurio-apicurio-registry
 - ../../../../base/core/namespaces/b4mad-racing
-- ../../../../base/core/namespaces/cosigned
 - ../../../../base/core/namespaces/boatrockers
+- ../../../../base/core/namespaces/cosigned
 - ../../../../base/core/namespaces/debezium-ui
 - ../../../../base/core/namespaces/democratic-csi
 - ../../../../base/core/namespaces/dex
@@ -64,6 +64,7 @@ resources:
 - ../../../../base/core/namespaces/rapidast
 - ../../../../base/core/namespaces/report-system
 - ../../../../base/core/namespaces/tekton-pipelines
+- ../../../../base/core/namespaces/testproject
 - ../../../../base/core/namespaces/thoth-amun-api-prod
 - ../../../../base/core/namespaces/thoth-amun-inspection-prod
 - ../../../../base/core/namespaces/thoth-backend-prod
@@ -96,9 +97,9 @@ resources:
 - ../../../../base/operators.coreos.com/subscriptions/opf-grafana
 - ../../../../base/operators.coreos.com/subscriptions/ovms-operator
 - ../../../../base/operators.coreos.com/subscriptions/pulp-operator
+- ../../../../base/operators.coreos.com/subscriptions/snapscheduler
 - ../../../../base/operators.coreos.com/subscriptions/strimzi
 - ../../../../base/operators.coreos.com/subscriptions/vertical-pod-autoscaler
-- ../../../../base/operators.coreos.com/subscriptions/snapscheduler
 - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/cluster-interceptor-opf-ci-pipelines
 - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/cluster-monitoring-view
 - ../../../../base/rbac.authorization.k8s.io/clusterrolebindings/jupyterhub-cluster


### PR DESCRIPTION
Testing PR for the `opfcli onboard` command, with the following sample onboarding config file:

```
env: MOC
namespaces:
  - enable_monitoring: false
    name: testproject
    quota: small
project_description: This is the configuration for a sample project / app to onboard
target_cluster: Smaug
team_name: testgroup
users:
  - testing_gh_handle_1
  - testing_gh_handle_2
```